### PR TITLE
Support mssql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Translator features with MSSQL support.
+- Dialect Enum.
+
+### Changed
+- Dataset sql(&self, query: &str) method changed to relation(&self, query: &str, dialect: Option<Dialect>).
+- Added optional dialect in the signature of Dataset's from_queries method.
+- Relation render() method changed to to_query(dialect: Option<Dialect>).
+- Relation parse(query: &str, dataset: &Dataset) method changed to from_query(query: &str, dataset: &Dataset, dialect: Option<Dialect>).
+
 ## [0.7.3] - 2024-01-04
 ### Removed
 - Dependency to matplotlib removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.20", features = ["abi3-py38"] }
-qrlew = "0.8.1"
+qrlew ={ version = "0.8.1", features = ["mssql"] }
 qrlew-sarus = "0.8.2"
 serde_json = "1.0"

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -3,7 +3,7 @@ use qrlew::{
     builder::With,
     hierarchy::Hierarchy,
     relation,
-    sql, dialect_translation::{postgres::PostgresTranslator, QueryToRelationTranslator, mssql::MSSQLTranslator, RelationToQueryTranslator},
+    sql, dialect_translation::{postgres::PostgresTranslator, QueryToRelationTranslator, mssql::MSSQLTranslator},
 };
 use qrlew_sarus::{data_spec, protobuf::print_to_string};
 use std::ops::Deref;

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -60,7 +60,7 @@ impl Dataset {
             .collect()
     }
 
-    pub fn sql(&self, query: &str) -> Result<Relation> {
+    pub fn relation(&self, query: &str) -> Result<Relation> {
         let query = sql::relation::parse(query)?;
         let relations = self.deref().relations();
         let query_with_relations = query.with(&relations);

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -3,13 +3,13 @@ use qrlew::{
     builder::With,
     hierarchy::Hierarchy,
     relation,
-    sql,
+    sql, dialect_translation::{postgres::PostgresTranslator, QueryToRelationTranslator, mssql::MSSQLTranslator, RelationToQueryTranslator},
 };
 use qrlew_sarus::{data_spec, protobuf::print_to_string};
 use std::ops::Deref;
 use std::sync::Arc;
 
-use crate::{error::Result, relation::Relation};
+use crate::{error::Result, relation::{Relation, Dialect}};
 
 /// A Dataset is a set of SQL Tables
 #[pyclass]
@@ -60,23 +60,50 @@ impl Dataset {
             .collect()
     }
 
-    pub fn relation(&self, query: &str) -> Result<Relation> {
-        let query = sql::relation::parse(query)?;
+    pub fn relation(&self, query: &str, dialect: Option<Dialect>) -> Result<Relation> {
+        let dialect = dialect.unwrap_or(Dialect::Postgres);
         let relations = self.deref().relations();
-        let query_with_relations = query.with(&relations);
-        Ok(Relation::new(Arc::new(query_with_relations.try_into()?)))
+        
+        match dialect {
+            Dialect::Postgres => {
+                let translator = PostgresTranslator;
+                let query = sql::relation::parse_with_dialect(query, translator.dialect())?;
+                let query_with_relations = query.with(&relations);
+                Ok(Relation::new(Arc::new(relation::Relation::try_from((query_with_relations, translator))?)))
+            },
+            Dialect::Mssql => {
+                let translator = MSSQLTranslator;
+                let query = sql::relation::parse_with_dialect(query, translator.dialect())?;
+                let query_with_relations = query.with(&relations);
+                Ok(Relation::new(Arc::new(relation::Relation::try_from((query_with_relations, translator))?)))
+            }, 
+        
+        }  
     }
 
-    pub fn from_queries(&self, queries: Vec<(Vec<String>, String)>) -> Result<Self> {
+    pub fn from_queries(&self, queries: Vec<(Vec<String>, String)>, dialect: Option<Dialect>) -> Result<Self> {
         let relations = self.deref().relations();
+        let dialect = dialect.unwrap_or(Dialect::Postgres);
 
         let result_relations: Hierarchy<Arc<relation::Relation>> = queries
             .iter()
             .map(|(path, query)| {
-                let parsed = sql::relation::parse(query)?;
-                let query_with_rel = parsed.with(&relations);
-                let rel = relation::Relation::try_from(query_with_rel)?;
-                Ok((path.clone(), Arc::new(rel)))
+                match dialect {
+                    Dialect::Postgres => {
+                        let tranlator = PostgresTranslator;
+                        let parsed = sql::relation::parse_with_dialect(query, tranlator.dialect())?;
+                        let query_with_rel = parsed.with(&relations);
+                        let rel = relation::Relation::try_from((query_with_rel, tranlator))?;
+                        Ok((path.clone(), Arc::new(rel)))
+                    },
+                    Dialect::Mssql => {
+                        let tranlator = MSSQLTranslator;
+                        let parsed = sql::relation::parse_with_dialect(query, tranlator.dialect())?;
+                        let query_with_rel = parsed.with(&relations);
+                        let rel = relation::Relation::try_from((query_with_rel, tranlator))?;
+                        Ok((path.clone(), Arc::new(rel)))
+                    }
+                }
             })
             .collect::<Result<Hierarchy<Arc<relation::Relation>>>>()?;
         let ds: data_spec::Dataset = (&result_relations).try_into()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ pub mod error;
 pub mod relation;
 pub mod dp_event;
 
-use crate::{dataset::Dataset, relation::Relation};
+use crate::{dataset::Dataset, relation::{Relation, Dialect}};
 use pyo3::prelude::{pymodule, PyModule, PyResult, Python};
 
 /// A Python module implemented in Rust.
@@ -11,5 +11,6 @@ use pyo3::prelude::{pymodule, PyModule, PyResult, Python};
 fn pyqrlew(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Dataset>()?;
     m.add_class::<Relation>()?;
+    m.add_class::<Dialect>()?;
     Ok(())
 }

--- a/src/relation.rs
+++ b/src/relation.rs
@@ -48,8 +48,8 @@ impl Relation {
 #[pymethods]
 impl Relation {
     #[staticmethod]
-    pub fn parse(query: &str, dataset: &Dataset) -> Result<Self> {
-        dataset.relation(query)
+    pub fn from_query(query: &str, dataset: &Dataset, dialect: Option<Dialect>) -> Result<Self> {
+        dataset.relation(query, dialect)
     }
 
     pub fn __str__(&self) -> String {
@@ -139,12 +139,6 @@ impl Relation {
         )))
     }
 
-    #[staticmethod]
-    pub fn from_query(dataset: &Dataset, query: String, dialect: Option<Dialect>) -> Result<Self> {
-        todo!()
-    }
-
-    // or simply query?
     pub fn to_query(&self, dialect: Option<Dialect>) -> String {
         let relation = &*(self.0);
         let dialect = dialect.unwrap_or(Dialect::Postgres);
@@ -161,7 +155,7 @@ mod tests {
 
     use crate::{
         dataset::Dataset,
-        relation::{Relation,Dialect}
+        relation::{Relation, Dialect}
     };
     use std::collections::HashMap;
 
@@ -187,7 +181,7 @@ mod tests {
         ];
 
         for query in queries {
-            let relation = Relation::parse(query, &dataset).unwrap();
+            let relation = Relation::from_query(query, &dataset, None).unwrap();
             println!("{}", relation.0);
             let dp_relation = relation.rewrite_with_differential_privacy(
                 &dataset, privacy_unit.clone(), budget.clone(), synthetic_data.clone()
@@ -198,7 +192,7 @@ mod tests {
 
         // No synthetic data
         for query in queries {
-            let relation = Relation::parse(query, &dataset).unwrap();
+            let relation = Relation::from_query(query, &dataset, None).unwrap();
             println!("{}", relation.0);
             let dp_relation = relation.rewrite_with_differential_privacy(
                 &dataset, privacy_unit.clone(), budget.clone(), None

--- a/src/relation.rs
+++ b/src/relation.rs
@@ -1,20 +1,18 @@
 use crate::{
     dataset::Dataset,
     error::{MissingKeysError, Result},
-    dp_event::{DpEvent, RelationWithDpEvent},
+    dp_event::RelationWithDpEvent,
 };
 use pyo3::prelude::*;
 use qrlew::{
     ast,
-    differential_privacy::{budget::Budget, dp_event},
+    differential_privacy::budget::Budget,
     expr::Identifier,
     privacy_unit_tracking::PrivacyUnit,
     relation::{self, Variant},
-    rewriting::rewriting_rule,
     synthetic_data::SyntheticData,
-    dialect_translation::{RelationToQueryTranslator, RelationWithTranslator, postgres::PostgresTranslator, mssql::MSSQLTranslator}
+    dialect_translation::{RelationWithTranslator, postgres::PostgresTranslator, mssql::MSSQLTranslator}
 };
-use qrlew_sarus::protobuf::transform::transform::external::op_identifier::Op;
 use std::{collections::HashMap, ops::Deref, str, sync::Arc};
 
 

--- a/tests/test_base_queries.py
+++ b/tests/test_base_queries.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 from pyqrlew.io import PostgreSQL
 from termcolor import colored
+from pyqrlew import Dialect
 
 def are_dataframes_almost_equal(df1, df2, float_tolerance=1e-6):
     # Check if the shape is the same
@@ -89,3 +90,12 @@ def test_queries_differential_privacy(queries):
         dp_results = pd.read_sql(dp_relation.to_query(), database.engine())
         if len(dp_results) != 0:
             assert (results.columns == dp_results.columns).all()
+
+
+def test_simple_mssql_translation():
+    database = PostgreSQL()
+    dataset = database.extract()
+    query = "SELECT * FROM census LIMIT 10;"
+    relation = dataset.relation(query, Dialect.Postgres)
+    translated = relation.to_query(Dialect.Mssql)
+    assert "SELECT TOP (10) * FROM" in translated

--- a/tests/test_base_queries.py
+++ b/tests/test_base_queries.py
@@ -49,8 +49,8 @@ def test_queries_consistency(queries):
         print(f"\n{colored(query, 'blue')}")
         replaced_query = query.replace("census", "extract.census").replace("beacon", "extract.beacon")
         result = pd.read_sql(replaced_query, database.engine())            
-        relation = dataset.sql(query)
-        new_query = relation.render()
+        relation = dataset.relation(query)
+        new_query = relation.to_query()
         print('===================')
         print(f"{colored(query, 'red')} -> {colored(new_query, 'green')}")
         try:
@@ -78,14 +78,14 @@ def test_queries_differential_privacy(queries):
     dataset = database.extract()
     for query in queries:
         print(f"{colored(query, 'blue')}")
-        relation = dataset.sql(query)
+        relation = dataset.relation(query)
         dp_relation = relation.rewrite_with_differential_privacy(
             dataset,
             privacy_unit,
             budget,
             synthetic_data,
         ).relation()
-        results = pd.read_sql(relation.render(), database.engine())
-        dp_results = pd.read_sql(dp_relation.render(), database.engine())
+        results = pd.read_sql(relation.to_query(), database.engine())
+        dp_results = pd.read_sql(dp_relation.to_query(), database.engine())
         if len(dp_results) != 0:
             assert (results.columns == dp_results.columns).all()


### PR DESCRIPTION
Add translators from qrlew with mssql support. Add optinal dialect (as an enum) in the signature of every function that takes a query: str argument. Change some function names: Dataset.sql -> Dataset.relation, Relation.parse ->  Relation.from_query, Relation.render -> Relation.to_query
